### PR TITLE
Add hidden debug section for file info

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,10 @@
                     </button>
                 </div>
                 <div id="fileError" class="text-red-500 text-sm mt-2 hidden"></div>
+                <div id="debugSection" class="mt-4 hidden">
+                    <h3 class="text-sm font-medium text-gray-700 mb-2">Información del archivo</h3>
+                    <pre id="debugOutput" class="hidden bg-gray-100 p-2 rounded text-xs overflow-x-auto"></pre>
+                </div>
             </div>
 
             <div class="bg-white rounded-xl shadow-lg p-6 mb-8" id="participantsSection" style="display: none;">
@@ -260,14 +264,17 @@
             reader.readAsArrayBuffer(file);
             
             // Show debug info
-            document.getElementById('debugSection').classList.remove('hidden');
+            const debugSection = document.getElementById('debugSection');
+            const debugOutput = document.getElementById('debugOutput');
+            debugSection.classList.remove('hidden');
+            debugOutput.classList.remove('hidden');
             const debugInfo = {
                 fileName: file.name,
                 fileSize: `${(file.size / 1024 / 1024).toFixed(2)} MB`,
                 fileType: file.type,
                 lastModified: new Date(file.lastModified).toLocaleString()
             };
-            document.getElementById('debugOutput').textContent = JSON.stringify(debugInfo, null, 2);
+            debugOutput.textContent = JSON.stringify(debugInfo, null, 2);
         }
 
         // Evento para importar participantes


### PR DESCRIPTION
## Summary
- define hidden debug section elements for showing file metadata
- reveal debug output when a file is loaded

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bc585e418832faa1c86a36cf11604