### PR TITLE
Remove file debug info from upload UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,10 +59,6 @@
                     </button>
                 </div>
                 <div id="fileError" class="text-red-500 text-sm mt-2 hidden"></div>
-                <div id="debugSection" class="mt-4 hidden">
-                    <h3 class="text-sm font-medium mb-2">Información del archivo</h3>
-                    <pre id="debugOutput" class="hidden bg-gray-100 p-2 rounded text-xs overflow-x-auto"></pre>
-                </div>
             </div>
 
             <div class="card p-6 mb-8" id="participantsSection" style="display: none;">
@@ -280,18 +276,6 @@
             };
             reader.readAsArrayBuffer(file);
             
-            // Show debug info
-            const debugSection = document.getElementById('debugSection');
-            const debugOutput = document.getElementById('debugOutput');
-            debugSection.classList.remove('hidden');
-            debugOutput.classList.remove('hidden');
-            const debugInfo = {
-                fileName: file.name,
-                fileSize: `${(file.size / 1024 / 1024).toFixed(2)} MB`,
-                fileType: file.type,
-                lastModified: new Date(file.lastModified).toLocaleString()
-            };
-            debugOutput.textContent = JSON.stringify(debugInfo, null, 2);
         }
 
         // Evento para importar participantes


### PR DESCRIPTION
### Motivation
- El componente mostraba un bloque de depuración con `JSON.stringify` que mostraba metadatos del archivo en la UI; se elimina porque es información de debug no deseada y no debe renderizarse al usuario.

### Description
- Eliminado el bloque HTML con el `id` `debugSection` y el `pre` con `id` `debugOutput` del formulario de subida.
- Eliminada la lógica JavaScript que mostraba y poblaba `debugSection`/`debugOutput` (el objeto `debugInfo` y la llamada a `JSON.stringify`).
- Se conservaron intactas la lectura del archivo, el llenado de los `select` de columnas y la función de importación (`importParticipants`) y el botón `Importar participantes`.

### Testing
- No se ejecutaron pruebas unitarias automáticas; se intentó una verificación visual con Playwright pero falló al lanzar el navegador en este entorno (error de proceso/CRASH), por lo que no se generó screenshot ni prueba visual exitosa.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982168e7f48832f937346e9006b14e3)