### PR TITLE
Ajuste de tamaño de logos en header para coincidir con el screenshot

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 <body class="min-h-screen">
     <div class="container mx-auto px-4 py-8 max-w-4xl">
         <header class="text-center mb-12">
-            <div class="brand-header mb-6" role="banner" aria-label="Marcas organizadoras">
+            <div class="brand-header topbar mb-6" role="banner" aria-label="Marcas organizadoras">
                 <img src="assets/logos/crea-plus.svg" alt="Logo Crea+" class="brand-logo" />
                 <img src="assets/logos/pacifico.svg" alt="Logo Pacífico" class="brand-logo" />
             </div>

--- a/styles.css
+++ b/styles.css
@@ -22,24 +22,45 @@ h1,h2,h3,.heading{
   color: var(--color-brand);
 }
 
+.topbar,
 .brand-header{
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
-.brand-logo{
-  height: clamp(48px, 8vw, 56px);
-  width: auto;
-  max-width: 100%;
+.topbar .logo,
+.topbar img,
+.topbar svg,
+.brand-header .brand-logo,
+.brand-header .brand-logo svg{
+  height: 48px !important;
+  max-height: 56px;
+  width: auto !important;
+  max-width: 180px;
   object-fit: contain;
+  display: block;
+  flex: 0 0 auto;
 }
 
-@media (max-width: 640px){
+@media (max-width: 480px){
+  .topbar,
   .brand-header{
+    flex-wrap: wrap;
     justify-content: center;
+    gap: 12px;
+  }
+
+  .topbar .logo,
+  .topbar img,
+  .topbar svg,
+  .brand-header .brand-logo,
+  .brand-header .brand-logo svg{
+    height: 40px !important;
+    max-height: 44px;
+    max-width: 160px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Los logos SVG del header se mostraban sobredimensionados respecto a la referencia visual proporcionada, por lo que era necesario limitar su escala en el layout del header.
- Hay que preservar el layout flex del encabezado mientras se evita que las imágenes crezcan por comportamiento de flex o reglas globales.

### Description
- Se añadió la clase `topbar` en el contenedor del header en `index.html` para delimitar el alcance de las reglas de estilo del header.
- En `styles.css` se agregaron selectores específicos de header (`.topbar img`, `.topbar svg`, `.brand-header .brand-logo`, etc.) que imponen `height: 48px !important`, `max-height: 56px`, `width: auto !important`, `max-width: 180px`, `object-fit: contain` y `flex: 0 0 auto` para evitar escalados indeseados.
- Se eliminó la regla de tamaño flexible previa y se definió un ajuste móvil que reduce los logos a `height: 40px !important` con `max-height: 44px` y centra los elementos al hacer wrap.
- Los cambios limitan la posibilidad de que reglas globales de imágenes/SVG sobrescriban la apariencia del header manteniendo compatibilidad con distintos tamaños de pantalla.

### Testing
- Se levantó un servidor local con `python3 -m http.server 4173` y la página se sirvió correctamente.
- Se capturaron capturas de escritorio y móvil mediante un script Playwright (artefactos `updated-desktop.png` y `updated-mobile.png`) para validar la escala visual, y ambas ejecuciones fueron exitosas.
- Se verificó que las reglas actualizadas aparecen en `styles.css` y se aplican en la página en ejecución.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996274ca044832fb317d56b49aa93bb)