### PR TITLE
Ajusta visualización de logos en el header

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
     <div class="container mx-auto px-4 py-8 max-w-4xl">
         <header class="text-center mb-12">
             <div class="brand-header topbar mb-6" role="banner" aria-label="Marcas organizadoras">
-                <img src="assets/logos/crea-plus.svg" alt="Logo Crea+" class="brand-logo" />
-                <img src="assets/logos/pacifico.svg" alt="Logo Pacífico" class="brand-logo" />
+                <img src="assets/logos/crea-plus.svg" alt="Logo Crea+" class="brand-logo brand-logo--crea" />
+                <img src="assets/logos/pacifico.svg" alt="Logo Pacífico" class="brand-logo brand-logo--pacifico" />
             </div>
             <h1 class="text-3xl font-bold mb-2">Gana y Cambia Vidas</h1>
             <p class="text-gray-600">Participa en nuestros sorteos solidarios</p>

--- a/styles.css
+++ b/styles.css
@@ -26,7 +26,7 @@ h1,h2,h3,.heading{
 .brand-header{
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 1rem;
 }
 
@@ -34,20 +34,28 @@ h1,h2,h3,.heading{
 .topbar img,
 .topbar svg,
 .brand-header .brand-logo{
-  height: 56px;
+  height: 40px;
   width: auto;
-  max-width: 180px;
+  max-width: 140px;
   object-fit: contain;
   display: block;
   flex: 0 0 auto;
 }
 
+.brand-header .brand-logo--crea{
+  max-width: 130px;
+}
+
+.brand-header .brand-logo--pacifico{
+  max-width: 120px;
+}
+
 .topbar .logo img,
 .topbar .logo svg,
 .brand-header .brand-logo svg{
-  height: 56px;
+  height: 40px;
   width: auto;
-  max-width: 180px;
+  max-width: 140px;
 }
 
 @media (max-width: 480px){
@@ -64,8 +72,13 @@ h1,h2,h3,.heading{
   .topbar .logo img,
   .topbar .logo svg,
   .brand-header .brand-logo svg{
-    height: 44px;
-    max-width: 160px;
+    height: 32px;
+    max-width: 120px;
+  }
+
+  .brand-header .brand-logo--crea,
+  .brand-header .brand-logo--pacifico{
+    max-width: 110px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Mejorar la apariencia del bloque de marcas del encabezado para que los logos no se vean sobredimensionados y se asemejen al screenshot de referencia.

### Description
- Agregué clases específicas en `index.html` para controlar cada logo: `brand-logo--crea` y `brand-logo--pacifico`.
- Centré el contenedor de marcas cambiando la alineación de `.brand-header`/`.topbar` y reduje la altura base de los logos de `56px` a `40px` en `styles.css`.
- Añadí límites de `max-width` independientes por marca y ajustes dentro de `@media (max-width: 480px)` para mantener proporciones en móvil.

### Testing
- Validé visualmente arrancando un servidor HTTP temporal (`python3 -m http.server`) y generando una captura de la página con Playwright; la imagen se creó correctamente y muestra los logos con el tamaño esperado.
- Revisé los cambios en `index.html` y `styles.css` para confirmar las reglas CSS aplicadas y las nuevas clases de logo.
- No hay tests unitarios aplicables; la verificación automatizada realizada fue de tipo visual y tuvo éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699629d42134832f91b85506d42340a2)