### PR TITLE
Agregar animación de ruleta previa al cálculo del ganador

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,37 +386,56 @@
                 alert(`No hay suficientes participantes (${participants.length}) para seleccionar ${winnerCount} ganadores`);
                 return;
             }
-            
-            // Seleccionar ganadores aleatorios sin repetición
-            winners = [];
-            const participantsCopy = [...participants];
-            
-            for (let i = 0; i < winnerCount; i++) {
-                const randomIndex = Math.floor(Math.random() * participantsCopy.length);
-                winners.push(participantsCopy[randomIndex]);
-                participantsCopy.splice(randomIndex, 1);
-            }
-            
-            // Mostrar ganadores
+
+            drawBtn.disabled = true;
             displayPrize.textContent = prize;
-            winnerList.innerHTML = '';
-            
-            winners.forEach((winner, index) => {
-                const winnerElement = document.createElement('div');
-                winnerElement.className = 'text-lg';
-                if (winner.email) {
-                    winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name} &lt;${winner.email}&gt;`;
-                } else {
-                    winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name}`;
-                }
-                winnerList.appendChild(winnerElement);
-            });
-            
-            // Mostrar contenedor de ganadores
             winnerContainer.style.display = 'block';
-            
-            // Desplazarse hasta los ganadores
-            winnerContainer.scrollIntoView({ behavior: 'smooth' });
+            winnerList.innerHTML = '';
+
+            const rouletteElement = document.createElement('div');
+            rouletteElement.className = 'text-lg font-semibold';
+            winnerList.appendChild(rouletteElement);
+
+            const rouletteDuration = 10000;
+            const rouletteSpeed = 80;
+
+            const rouletteInterval = setInterval(() => {
+                const randomIndex = Math.floor(Math.random() * participants.length);
+                rouletteElement.innerHTML = `🎯 ${participants[randomIndex].name}`;
+            }, rouletteSpeed);
+
+            setTimeout(() => {
+                clearInterval(rouletteInterval);
+
+                // Seleccionar ganadores aleatorios sin repetición
+                winners = [];
+                const participantsCopy = [...participants];
+                
+                for (let i = 0; i < winnerCount; i++) {
+                    const randomIndex = Math.floor(Math.random() * participantsCopy.length);
+                    winners.push(participantsCopy[randomIndex]);
+                    participantsCopy.splice(randomIndex, 1);
+                }
+                
+                // Mostrar ganadores
+                winnerList.innerHTML = '';
+                
+                winners.forEach((winner, index) => {
+                    const winnerElement = document.createElement('div');
+                    winnerElement.className = 'text-lg';
+                    if (winner.email) {
+                        winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name} &lt;${winner.email}&gt;`;
+                    } else {
+                        winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name}`;
+                    }
+                    winnerList.appendChild(winnerElement);
+                });
+
+                drawBtn.disabled = false;
+                
+                // Desplazarse hasta los ganadores
+                winnerContainer.scrollIntoView({ behavior: 'smooth' });
+            }, rouletteDuration);
         }
 
         // Evento para nuevo sorteo


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia visual mostrando una animación tipo ruleta antes de revelar el ganador sin cambiar la lógica de selección existente.
- Simular una tómbola mostrando nombres aleatorios rápidamente durante 10 segundos usando APIs nativas de JavaScript.

### Description
- Se actualizó `selectWinner()` para mostrar el premio inmediatamente, abrir el contenedor de ganadores y añadir un `rouletteElement` dentro de `winnerList` que muestra nombres aleatorios.
- La animación usa `setInterval` con un intervalo de ~80 ms y dura 10 segundos (`10000 ms`), luego se limpia el intervalo con `clearInterval` y se ejecuta exactamente la misma lógica original de selección aleatoria sin repetición usando `Math.random()`.
- El botón `drawBtn` queda deshabilitado durante la animación para evitar múltiples clics y se vuelve a habilitar después de mostrar los ganadores.
- Se reutilizan los elementos DOM existentes (`displayPrize`, `winnerContainer`, `winnerList`) para mantener el diseño actual sin cambios estructurales.

### Testing
- Se sirvió la página con `python -m http.server 8000` y se tomó una captura con Playwright navegando a `http://127.0.0.1:8000/index.html`, la ejecución finalizó correctamente.
- Se verificó localmente la actualización del bloque JavaScript en `index.html` y el repositorio aceptó el cambio (`git commit`), sin pruebas automatizadas fallidas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab12f1baf0832f93e6706642bc9f00)