### PR TITLE
Agregar overlay de cuenta regresiva (10→1) antes del sorteo

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,10 @@
         </footer>
     </div>
 
+    <div id="countdownOverlay" class="countdown-overlay hidden" aria-hidden="true">
+        <div id="countdownNumber" class="countdown-number">10</div>
+    </div>
+
     <script>
         // Variables globales
         let participants = [];
@@ -166,6 +170,10 @@
         const newDrawBtn = document.getElementById('newDrawBtn');
         const prizeNameInput = document.getElementById('prizeName');
         const winnerCountSelect = document.getElementById('winnerCount');
+        const countdownOverlay = document.getElementById('countdownOverlay');
+        const countdownNumber = document.getElementById('countdownNumber');
+
+        let isCountdownRunning = false;
 
         // Eventos para el área de arrastrar y soltar
         dropArea.addEventListener('click', () => fileInput.click());
@@ -366,7 +374,34 @@
         }
 
         // Evento para seleccionar ganador
-        drawBtn.addEventListener('click', selectWinner);
+        drawBtn.addEventListener('click', startCountdownBeforeDraw);
+
+        function startCountdownBeforeDraw() {
+            if (isCountdownRunning) return;
+
+            isCountdownRunning = true;
+            countdownOverlay.classList.remove('hidden');
+            countdownOverlay.setAttribute('aria-hidden', 'false');
+
+            let currentCount = 10;
+            countdownNumber.textContent = currentCount;
+
+            const countdownInterval = setInterval(() => {
+                currentCount -= 1;
+
+                if (currentCount > 0) {
+                    countdownNumber.textContent = currentCount;
+                    return;
+                }
+
+                clearInterval(countdownInterval);
+                countdownOverlay.classList.add('hidden');
+                countdownOverlay.setAttribute('aria-hidden', 'true');
+                isCountdownRunning = false;
+                selectWinner();
+
+            }, 1000);
+        }
 
         function selectWinner() {
             const prize = prizeNameInput.value.trim();
@@ -422,7 +457,7 @@
                 
                 winners.forEach((winner, index) => {
                     const winnerElement = document.createElement('div');
-                    winnerElement.className = 'text-lg';
+                    winnerElement.className = 'text-lg winner-name';
                     if (winner.email) {
                         winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name} &lt;${winner.email}&gt;`;
                     } else {

--- a/styles.css
+++ b/styles.css
@@ -119,3 +119,30 @@ h1,h2,h3,.heading{
   70%{transform: scale(1.05); box-shadow: 0 0 0 10px rgba(74,222,128,0);}
   100%{transform: scale(1); box-shadow: 0 0 0 0 rgba(74,222,128,0);}
 }
+
+
+.countdown-overlay{
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.countdown-overlay.hidden{
+  display: none;
+}
+
+.countdown-number{
+  font-family: 'Atkinson Hyperlegible', sans-serif;
+  font-size: clamp(6rem, 24vw, 16rem);
+  font-weight: 700;
+  color: #fff;
+  line-height: 1;
+}
+
+.winner-name{
+  font-family: 'FF Nort Headline', 'Atkinson Hyperlegible', sans-serif;
+}


### PR DESCRIPTION
### Motivation
- Añadir una animación previa al momento de seleccionar ganadores para generar expectativa sin tocar la lógica existente del sorteo.

### Description
- Inserté un overlay full-screen en `index.html` con `#countdownOverlay` y `#countdownNumber` que muestra la cuenta regresiva del 10 al 1.
- Implementé `startCountdownBeforeDraw()` y cambié el listener de `drawBtn` para iniciar la cuenta regresiva y llamar a la función original `selectWinner()` al finalizar, sin modificar su lógica interna.
- Añadí estilos en `styles.css` para el overlay oscuro centrado y el tamaño responsivo del número, usando `Atkinson Hyperlegible` para el contador y `FF Nort Headline` para los nombres de ganadores (clase `winner-name`).
- Marqué los elementos de ganador con la nueva clase `winner-name` para aplicar la tipografía solicitada sin alterar el contenido ni el flujo del sorteo.

### Testing
- Ejecuté `git diff --check` para detectar problemas de formato y la comprobación final pasó correctamente. (éxito)
- Levanté un servidor local con `python3 -m http.server 4173` y la página se sirvió correctamente en `http://127.0.0.1:4173/index.html`. (éxito)
- Ejecuté un script Playwright que abrió la página, forzó la visualización del overlay y generó una captura de pantalla del overlay de la cuenta regresiva; la captura confirmÓ que el overlay ocupa la pantalla y muestra el número centrado. (éxito)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab157a5790832f92546b4dfa9f2700)