### PR TITLE
Simplificar flujo: contador 10→1 y mostrar ganador en overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,7 @@
 
     <div id="countdownOverlay" class="countdown-overlay hidden" aria-hidden="true">
         <div id="countdownNumber" class="countdown-number">10</div>
+        <div id="overlayWinnerName" class="overlay-winner-name hidden"></div>
     </div>
 
     <script>
@@ -172,6 +173,7 @@
         const winnerCountSelect = document.getElementById('winnerCount');
         const countdownOverlay = document.getElementById('countdownOverlay');
         const countdownNumber = document.getElementById('countdownNumber');
+        const overlayWinnerName = document.getElementById('overlayWinnerName');
 
         let isCountdownRunning = false;
 
@@ -379,7 +381,30 @@
         function startCountdownBeforeDraw() {
             if (isCountdownRunning) return;
 
+            const prize = prizeNameInput.value.trim();
+            const winnerCount = parseInt(winnerCountSelect.value);
+
+            if (!prize) {
+                alert('Por favor ingresa el nombre del premio');
+                return;
+            }
+
+            if (participants.length === 0) {
+                alert('No hay participantes cargados');
+                return;
+            }
+
+            if (winnerCount > participants.length) {
+                alert(`No hay suficientes participantes (${participants.length}) para seleccionar ${winnerCount} ganadores`);
+                return;
+            }
+
             isCountdownRunning = true;
+            drawBtn.disabled = true;
+            winnerContainer.style.display = 'none';
+            countdownNumber.classList.remove('hidden');
+            overlayWinnerName.classList.add('hidden');
+            overlayWinnerName.textContent = '';
             countdownOverlay.classList.remove('hidden');
             countdownOverlay.setAttribute('aria-hidden', 'false');
 
@@ -395,11 +420,7 @@
                 }
 
                 clearInterval(countdownInterval);
-                countdownOverlay.classList.add('hidden');
-                countdownOverlay.setAttribute('aria-hidden', 'true');
-                isCountdownRunning = false;
                 selectWinner();
-
             }, 1000);
         }
 
@@ -422,55 +443,38 @@
                 return;
             }
 
-            drawBtn.disabled = true;
             displayPrize.textContent = prize;
             winnerContainer.style.display = 'block';
             winnerList.innerHTML = '';
 
-            const rouletteElement = document.createElement('div');
-            rouletteElement.className = 'text-lg font-semibold';
-            winnerList.appendChild(rouletteElement);
+            // Seleccionar ganadores aleatorios sin repetición
+            winners = [];
+            const participantsCopy = [...participants];
 
-            const rouletteDuration = 10000;
-            const rouletteSpeed = 80;
+            for (let i = 0; i < winnerCount; i++) {
+                const randomIndex = Math.floor(Math.random() * participantsCopy.length);
+                winners.push(participantsCopy[randomIndex]);
+                participantsCopy.splice(randomIndex, 1);
+            }
 
-            const rouletteInterval = setInterval(() => {
-                const randomIndex = Math.floor(Math.random() * participants.length);
-                rouletteElement.innerHTML = `🎯 ${participants[randomIndex].name}`;
-            }, rouletteSpeed);
-
-            setTimeout(() => {
-                clearInterval(rouletteInterval);
-
-                // Seleccionar ganadores aleatorios sin repetición
-                winners = [];
-                const participantsCopy = [...participants];
-                
-                for (let i = 0; i < winnerCount; i++) {
-                    const randomIndex = Math.floor(Math.random() * participantsCopy.length);
-                    winners.push(participantsCopy[randomIndex]);
-                    participantsCopy.splice(randomIndex, 1);
+            // Mostrar ganadores en la tarjeta inferior
+            winners.forEach((winner, index) => {
+                const winnerElement = document.createElement('div');
+                winnerElement.className = 'text-lg winner-name';
+                if (winner.email) {
+                    winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name} &lt;${winner.email}&gt;`;
+                } else {
+                    winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name}`;
                 }
-                
-                // Mostrar ganadores
-                winnerList.innerHTML = '';
-                
-                winners.forEach((winner, index) => {
-                    const winnerElement = document.createElement('div');
-                    winnerElement.className = 'text-lg winner-name';
-                    if (winner.email) {
-                        winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name} &lt;${winner.email}&gt;`;
-                    } else {
-                        winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name}`;
-                    }
-                    winnerList.appendChild(winnerElement);
-                });
+                winnerList.appendChild(winnerElement);
+            });
 
-                drawBtn.disabled = false;
-                
-                // Desplazarse hasta los ganadores
-                winnerContainer.scrollIntoView({ behavior: 'smooth' });
-            }, rouletteDuration);
+            countdownNumber.classList.add('hidden');
+            overlayWinnerName.textContent = winners.map((winner) => winner.name).join(' • ');
+            overlayWinnerName.classList.remove('hidden');
+
+            drawBtn.disabled = false;
+            isCountdownRunning = false;
         }
 
         // Evento para nuevo sorteo

--- a/styles.css
+++ b/styles.css
@@ -146,3 +146,20 @@ h1,h2,h3,.heading{
 .winner-name{
   font-family: 'FF Nort Headline', 'Atkinson Hyperlegible', sans-serif;
 }
+
+
+.overlay-winner-name{
+  font-family: 'FF Nort Headline', 'Atkinson Hyperlegible', sans-serif;
+  font-size: clamp(2.5rem, 9vw, 7rem);
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.1;
+  text-align: center;
+  max-width: min(92vw, 1200px);
+  word-break: break-word;
+  padding: 0 1rem;
+}
+
+.overlay-winner-name.hidden{
+  display: none;
+}


### PR DESCRIPTION
### Motivation
- Eliminar la segunda animación aleatoria (ruleta) y simplificar el flujo a un solo contador de 10→1 que invoque la selección final de ganadores una sola vez.
- Mantener la lógica actual de selección aleatoria sin repetición, preservando las tipografías solicitadas para contador y nombre final.

### Description
- Modifiqué `index.html` para añadir un elemento de overlay `overlayWinnerName` dentro del `countdownOverlay` y para ocultar `winnerContainer` cuando arranca el contador, llamando a `selectWinner()` solo al finalizar el conteo; los archivos afectados son `index.html` y `styles.css`.
- Eliminé todos los `setInterval`/`setTimeout` de la “ruleta” y la actualización continua de nombres, dejando la selección aleatoria final tal como estaba (sin repetición) y mostrando el/los nombre(s) ganador(es) en grande en el overlay.
- Añadí estilos `.overlay-winner-name` en `styles.css` para mostrar el nombre grande, centrado y claro, usando `FF Nort Headline` para el texto del ganador y `Atkinson Hyperlegible` para el número del contador.
- Al iniciar el contador, el botón de sorteo se desactiva y el overlay permanece en pantalla completa mostrando el número; al terminar se oculta el número y aparece el nombre final.

### Testing
- Ejecuté validación de sintaxis del script inline con `node -e "const fs=require('fs'); const html=fs.readFileSync('index.html','utf8'); const js=html.match(/<script>([\s\S]*)<\/script>/)[1]; new Function(js); console.log('inline script syntax ok');"` y la comprobación fue exitosa.
- Verifiqué que se eliminaran referencias a la animación de ruleta con `rg -n "roulette|rouletteDuration|rouletteSpeed|rouletteInterval" index.html` y la comprobación confirmó que ya no hay referencias (éxito).
- Intenté generar una captura de pantalla automatizada con Playwright para validar visualmente el overlay, pero la ejecución falló en este entorno (`ERR_EMPTY_RESPONSE` / `ERR_FILE_NOT_FOUND`) y no fue posible obtener la imagen (falla reportada).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab1efcd21c832fb6d0577e26cf30b0)