### PR TITLE
Add overlay close (X) and "Nuevo sorteo" controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,8 +143,12 @@
     </div>
 
     <div id="countdownOverlay" class="countdown-overlay hidden" aria-hidden="true">
+        <button id="closeOverlayBtn" class="overlay-close-btn hidden" type="button" aria-label="Cerrar overlay de ganador">×</button>
         <div id="countdownNumber" class="countdown-number">10</div>
-        <div id="overlayWinnerName" class="overlay-winner-name hidden"></div>
+        <div id="overlayWinnerContent" class="overlay-winner-content hidden">
+            <div id="overlayWinnerName" class="overlay-winner-name"></div>
+            <button id="overlayNewDrawBtn" class="btn-primary overlay-new-draw-btn" type="button">Nuevo sorteo</button>
+        </div>
     </div>
 
     <script>
@@ -173,7 +177,10 @@
         const winnerCountSelect = document.getElementById('winnerCount');
         const countdownOverlay = document.getElementById('countdownOverlay');
         const countdownNumber = document.getElementById('countdownNumber');
+        const overlayWinnerContent = document.getElementById('overlayWinnerContent');
         const overlayWinnerName = document.getElementById('overlayWinnerName');
+        const closeOverlayBtn = document.getElementById('closeOverlayBtn');
+        const overlayNewDrawBtn = document.getElementById('overlayNewDrawBtn');
 
         let isCountdownRunning = false;
 
@@ -403,7 +410,8 @@
             drawBtn.disabled = true;
             winnerContainer.style.display = 'none';
             countdownNumber.classList.remove('hidden');
-            overlayWinnerName.classList.add('hidden');
+            closeOverlayBtn.classList.add('hidden');
+            overlayWinnerContent.classList.add('hidden');
             overlayWinnerName.textContent = '';
             countdownOverlay.classList.remove('hidden');
             countdownOverlay.setAttribute('aria-hidden', 'false');
@@ -471,11 +479,26 @@
 
             countdownNumber.classList.add('hidden');
             overlayWinnerName.textContent = winners.map((winner) => winner.name).join(' • ');
-            overlayWinnerName.classList.remove('hidden');
+            closeOverlayBtn.classList.remove('hidden');
+            overlayWinnerContent.classList.remove('hidden');
 
             drawBtn.disabled = false;
             isCountdownRunning = false;
         }
+
+        function closeOverlay() {
+            countdownOverlay.classList.add('hidden');
+            countdownOverlay.setAttribute('aria-hidden', 'true');
+            countdownNumber.classList.remove('hidden');
+            closeOverlayBtn.classList.add('hidden');
+            overlayWinnerContent.classList.add('hidden');
+            overlayWinnerName.textContent = '';
+            drawBtn.disabled = false;
+            isCountdownRunning = false;
+        }
+
+        closeOverlayBtn.addEventListener('click', closeOverlay);
+        overlayNewDrawBtn.addEventListener('click', closeOverlay);
 
         // Evento para nuevo sorteo
         newDrawBtn.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -163,3 +163,51 @@ h1,h2,h3,.heading{
 .overlay-winner-name.hidden{
   display: none;
 }
+
+
+.overlay-close-btn{
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: rgba(0, 0, 0, 0.35);
+  color: #fff;
+  font-family: 'Atkinson Hyperlegible', sans-serif;
+  font-size: 2rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.overlay-close-btn:hover{
+  background: rgba(255, 255, 255, 0.2);
+  transform: scale(1.05);
+}
+
+.overlay-close-btn.hidden{
+  display: none;
+}
+
+.overlay-winner-content{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  width: 100%;
+}
+
+.overlay-winner-content.hidden{
+  display: none;
+}
+
+.overlay-new-draw-btn{
+  font-family: 'Atkinson Hyperlegible', sans-serif;
+  min-width: 11rem;
+  text-align: center;
+}


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia al mostrar al ganador permitiendo cerrar el overlay o iniciar un nuevo sorteo sin recargar la página. 
- Mantener intacta la lógica existente del contador y la selección aleatoria de ganadores mientras se preserva la tipografía y el diseño actual.

### Description
- Añadidos elementos en `index.html`: un botón de cierre `#closeOverlayBtn` en la esquina superior y un botón centrado `#overlayNewDrawBtn` dentro del contenedor `#overlayWinnerContent` que muestra el nombre (`#overlayWinnerName`).
- Añadida la función en JavaScript `closeOverlay()` y se conectaron los eventos `closeOverlayBtn.addEventListener('click', closeOverlay)` y `overlayNewDrawBtn.addEventListener('click', closeOverlay)` para ocultar el overlay y restaurar el estado visual sin alterar la lógica del countdown ni la selección de ganadores.
- Ajustado el flujo de UI para mostrar/ocultar `#countdownNumber`, `#overlayWinnerContent` y `#closeOverlayBtn` en los puntos correctos de `startCountdownBeforeDraw()` y `selectWinner()` para permitir realizar un nuevo sorteo inmediatamente.
- Agregado CSS en `styles.css` para garantizar que la `X` sea claramente visible sobre el fondo oscuro, centrar el contenido del overlay y aplicar `Atkinson Hyperlegible` al botón de `Nuevo sorteo`, manteniendo `FF Nort Head` para el nombre del ganador.

### Testing
- Levanté un servidor estático con `python -m http.server` y comprobé que `index.html`, `styles.css` y fuentes se sirvieran correctamente, y la prueba automatizada finalizó con éxito.
- Ejecución de un script Playwright para abrir la página y generar una captura de pantalla del overlay con ambos controles, comprobando visualmente que los botones aparecen y el overlay puede mostrarse; la captura se generó correctamente.
- Verificación de cambios con `git diff` y revisión manual del wiring HTML/CSS/JS para confirmar que no se modificó la lógica del contador ni la selección de ganadores; la verificación automatizada y la revisión manual concluyeron satisfactoriamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab24d1fcb0832fbec560d267cb427a)