### PR TITLE
Ajustes visuales: overlay del ganador, tarjeta central y formato de lista

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,10 +121,14 @@
                         <p id="displayPrize" class="text-gray-600"></p>
                     </div>
 
-                    <div id="winnerDisplay" class="winner-animation card p-6 text-center">
-                        <h3 class="text-lg font-semibold mb-4">¡Ganador(es)!</h3>
+                    <div id="winnerDisplay" class="winner-highlight-card card p-6 text-center">
+                        <h3 class="winner-highlight-title">¡Tenemos ganador!</h3>
                         <div id="winnerHeroName" class="winner-hero-name"></div>
                         <p id="winnerCongrats" class="winner-congrats">¡Muchas felicidades!</p>
+                    </div>
+
+                    <div class="card p-6 text-center">
+                        <h3 class="text-lg font-semibold mb-4">¡Ganador(es)!</h3>
                         <div id="winnerList" class="space-y-2 text-gray-700">
                             <!-- Aquí se mostrarán los ganadores -->
                         </div>
@@ -152,7 +156,6 @@
         <div id="overlayWinnerContent" class="overlay-winner-content hidden">
             <p class="overlay-winner-label">El ganador es</p>
             <div id="overlayWinnerNumber" class="overlay-winner-number"></div>
-            <div id="overlayWinnerName" class="overlay-winner-name"></div>
             <button id="overlayNewDrawBtn" class="btn-primary overlay-new-draw-btn" type="button">Nuevo sorteo</button>
         </div>
     </div>
@@ -186,7 +189,6 @@
         const overlayNumberTicker = document.getElementById('overlayNumberTicker');
         const overlayWinnerContent = document.getElementById('overlayWinnerContent');
         const overlayWinnerNumber = document.getElementById('overlayWinnerNumber');
-        const overlayWinnerName = document.getElementById('overlayWinnerName');
         const winnerHeroName = document.getElementById('winnerHeroName');
         const winnerCongrats = document.getElementById('winnerCongrats');
         const closeOverlayBtn = document.getElementById('closeOverlayBtn');
@@ -471,7 +473,6 @@
             closeOverlayBtn.classList.add('hidden');
             overlayWinnerContent.classList.add('hidden');
             overlayWinnerNumber.textContent = '';
-            overlayWinnerName.textContent = '';
             startOverlayTicker();
             countdownOverlay.classList.remove('hidden');
             countdownOverlay.setAttribute('aria-hidden', 'false');
@@ -528,13 +529,18 @@
             // Mostrar ganadores en la tarjeta inferior
             const heroWinner = winners[0];
             winnerHeroName.textContent = heroWinner ? heroWinner.name : '';
+            winnerHeroName.classList.remove('winner-hero-name-animate');
+            if (heroWinner) {
+                void winnerHeroName.offsetWidth;
+                winnerHeroName.classList.add('winner-hero-name-animate');
+            }
             winnerCongrats.style.display = heroWinner ? 'block' : 'none';
 
             winners.forEach((winner, index) => {
                 const winnerElement = document.createElement('div');
                 winnerElement.className = 'text-lg winner-name';
                 if (winner.email) {
-                    winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name} &lt;${winner.email}&gt;`;
+                    winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name} - ${winner.email}`;
                 } else {
                     winnerElement.innerHTML = `<strong>${index + 1}.</strong> ${winner.name}`;
                 }
@@ -546,7 +552,6 @@
 
             countdownNumber.classList.add('hidden');
             overlayWinnerNumber.textContent = winnerNumber ? `N.° ${winnerNumber}` : '';
-            overlayWinnerName.textContent = heroWinner ? heroWinner.name : '';
             stopOverlayTicker(winnerNumber);
             closeOverlayBtn.classList.remove('hidden');
             overlayWinnerContent.classList.remove('hidden');
@@ -563,7 +568,6 @@
             overlayWinnerContent.classList.add('hidden');
             overlayNumberTicker.classList.add('hidden');
             overlayWinnerNumber.textContent = '';
-            overlayWinnerName.textContent = '';
             stopOverlayTicker();
             drawBtn.disabled = false;
             isCountdownRunning = false;

--- a/styles.css
+++ b/styles.css
@@ -141,15 +141,6 @@ h1,h2,h3,.heading{
   display: none;
 }
 
-.winner-animation{
-  animation: pulse 2s infinite;
-}
-@keyframes pulse{
-  0%{transform: scale(1); box-shadow: 0 0 0 0 rgba(74,222,128,0.7);}
-  70%{transform: scale(1.05); box-shadow: 0 0 0 10px rgba(74,222,128,0);}
-  100%{transform: scale(1); box-shadow: 0 0 0 0 rgba(74,222,128,0);}
-}
-
 .countdown-overlay{
   position: fixed;
   inset: 0;
@@ -172,6 +163,38 @@ h1,h2,h3,.heading{
   font-weight: 700;
   color: #fff;
   line-height: 1;
+}
+
+
+.winner-highlight-card{
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.winner-highlight-title{
+  font-family: 'Atkinson Hyperlegible', sans-serif;
+  font-size: clamp(1.2rem, 2.8vw, 1.6rem);
+  color: #0C00C0;
+  margin: 0 0 .6rem;
+}
+
+.winner-hero-name-animate{
+  animation: winnerNameReveal 950ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes winnerNameReveal{
+  0%{
+    transform: scale(0.9);
+    opacity: 0.75;
+  }
+  60%{
+    transform: scale(1.08);
+    opacity: 1;
+  }
+  100%{
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 .winner-name{
@@ -222,22 +245,6 @@ h1,h2,h3,.heading{
 }
 
 .overlay-number-ticker.hidden{
-  display: none;
-}
-
-.overlay-winner-name{
-  font-family: 'FF Nort Headline', 'Atkinson Hyperlegible', sans-serif;
-  font-size: clamp(2rem, 7vw, 4rem);
-  font-weight: 700;
-  color: #fff;
-  line-height: 1.1;
-  text-align: center;
-  max-width: min(92vw, 1200px);
-  word-break: break-word;
-  padding: 0 1rem;
-}
-
-.overlay-winner-name.hidden{
   display: none;
 }
 


### PR DESCRIPTION
### Motivation
- Mejorar la presentación visual de los resultados sin tocar la lógica del sorteo ni el comportamiento de los botones existentes.
- Mostrar en el overlay oscuro solo el texto pequeño "El ganador es" y el número grande, y mover el nombre del ganador a una tarjeta central más elegante.

### Description
- Se modificó `index.html` para eliminar el bloque que mostraba el nombre dentro del overlay y dejar solo `El ganador es` + número (`overlayWinnerNumber`).
- Se creó una tarjeta central blanca entre "Seleccionar ganador" y "¡Ganador(es)!" con el contenido: `¡Tenemos ganador!`, el nombre grande centrado y `¡Muchas felicidades!` (nuevo bloque `.winner-highlight-card`).
- Se separó la lista final de ganadores en su propia tarjeta y se cambió el formato de contacto de `<telefono>` a `- telefono` en la generación de la lista (`winnerElement.innerHTML = ... - ${winner.email}`).
- Se añadió la animación CSS `@keyframes winnerNameReveal` y la clase `.winner-hero-name-animate` para producir el efecto `scale(0.9) → scale(1.08) → scale(1)` al mostrar el nombre, y se añadió un pequeño ajuste JS para aplicar la clase al elemento cuando aparece el ganador; no se cambió la selección aleatoria, contador ni la lógica de reinicio.

### Testing
- Levanté el sitio localmente con `python -m http.server 4173` y verifiqué visualmente los cambios; prueba exitosa y captura generada en `artifacts/sorteo-ui-update.png`.
- Ejecuté `git diff` y `git status` para revisar las modificaciones; los cambios quedaron en `index.html` y `styles.css` y el commit fue creado con éxito.
- No se añadieron tests unitarios ya que los cambios son puramente de presentación y fueron validados mediante servidor local y captura de pantalla.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab41909850832f80b89265517864e8)