### PR TITLE
Ajustes visuales: animación continua del nombre, reubicación de tarjeta y botón "Ver ganador"

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,14 @@
                 </div>
             </div>
 
+            <div id="winnerHeroSection" class="winner-hero-section mb-8" style="display: none;">
+                <div id="winnerDisplay" class="winner-highlight-card card p-6 text-center">
+                    <h3 class="winner-highlight-title">¡Tenemos ganador!</h3>
+                    <div id="winnerHeroName" class="winner-hero-name"></div>
+                    <p id="winnerCongrats" class="winner-congrats">¡Muchas felicidades!</p>
+                </div>
+            </div>
+
             <div class="card p-6" id="raffleSection" style="display: none;">
                 <h2 class="text-xl font-semibold mb-4">Seleccionar ganador</h2>
                 
@@ -121,12 +129,6 @@
                         <p id="displayPrize" class="text-gray-600"></p>
                     </div>
 
-                    <div id="winnerDisplay" class="winner-highlight-card card p-6 text-center">
-                        <h3 class="winner-highlight-title">¡Tenemos ganador!</h3>
-                        <div id="winnerHeroName" class="winner-hero-name"></div>
-                        <p id="winnerCongrats" class="winner-congrats">¡Muchas felicidades!</p>
-                    </div>
-
                     <div class="card p-6 text-center">
                         <h3 class="text-lg font-semibold mb-4">¡Ganador(es)!</h3>
                         <div id="winnerList" class="space-y-2 text-gray-700">
@@ -156,7 +158,7 @@
         <div id="overlayWinnerContent" class="overlay-winner-content hidden">
             <p class="overlay-winner-label">El ganador es</p>
             <div id="overlayWinnerNumber" class="overlay-winner-number"></div>
-            <button id="overlayNewDrawBtn" class="btn-primary overlay-new-draw-btn" type="button">Nuevo sorteo</button>
+            <button id="overlayNewDrawBtn" class="btn-primary overlay-new-draw-btn" type="button">Ver ganador</button>
         </div>
     </div>
 
@@ -181,6 +183,7 @@
         const winnerContainer = document.getElementById('winnerContainer');
         const winnerList = document.getElementById('winnerList');
         const displayPrize = document.getElementById('displayPrize');
+        const winnerHeroSection = document.getElementById('winnerHeroSection');
         const newDrawBtn = document.getElementById('newDrawBtn');
         const prizeNameInput = document.getElementById('prizeName');
         const winnerCountSelect = document.getElementById('winnerCount');
@@ -529,11 +532,7 @@
             // Mostrar ganadores en la tarjeta inferior
             const heroWinner = winners[0];
             winnerHeroName.textContent = heroWinner ? heroWinner.name : '';
-            winnerHeroName.classList.remove('winner-hero-name-animate');
-            if (heroWinner) {
-                void winnerHeroName.offsetWidth;
-                winnerHeroName.classList.add('winner-hero-name-animate');
-            }
+            winnerHeroSection.style.display = heroWinner ? 'block' : 'none';
             winnerCongrats.style.display = heroWinner ? 'block' : 'none';
 
             winners.forEach((winner, index) => {
@@ -560,7 +559,7 @@
             isCountdownRunning = false;
         }
 
-        function closeOverlay() {
+        function closeOverlay(focusWinnerSection = false) {
             countdownOverlay.classList.add('hidden');
             countdownOverlay.setAttribute('aria-hidden', 'true');
             countdownNumber.classList.remove('hidden');
@@ -571,14 +570,19 @@
             stopOverlayTicker();
             drawBtn.disabled = false;
             isCountdownRunning = false;
+
+            if (focusWinnerSection && winnerHeroSection.style.display !== 'none') {
+                winnerHeroSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
         }
 
-        closeOverlayBtn.addEventListener('click', closeOverlay);
-        overlayNewDrawBtn.addEventListener('click', closeOverlay);
+        closeOverlayBtn.addEventListener('click', () => closeOverlay(false));
+        overlayNewDrawBtn.addEventListener('click', () => closeOverlay(true));
 
         // Evento para nuevo sorteo
         newDrawBtn.addEventListener('click', () => {
             winnerContainer.style.display = 'none';
+            winnerHeroSection.style.display = 'none';
             prizeNameInput.focus();
         });
     </script>

--- a/styles.css
+++ b/styles.css
@@ -171,6 +171,10 @@ h1,h2,h3,.heading{
   margin: 0 auto;
 }
 
+.winner-hero-section{
+  width: 100%;
+}
+
 .winner-highlight-title{
   font-family: 'Atkinson Hyperlegible', sans-serif;
   font-size: clamp(1.2rem, 2.8vw, 1.6rem);
@@ -178,22 +182,15 @@ h1,h2,h3,.heading{
   margin: 0 0 .6rem;
 }
 
-.winner-hero-name-animate{
-  animation: winnerNameReveal 950ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-@keyframes winnerNameReveal{
+@keyframes winnerNameBreath{
   0%{
-    transform: scale(0.9);
-    opacity: 0.75;
+    transform: scale(1);
   }
-  60%{
-    transform: scale(1.08);
-    opacity: 1;
+  50%{
+    transform: scale(1.05);
   }
   100%{
     transform: scale(1);
-    opacity: 1;
   }
 }
 
@@ -207,6 +204,9 @@ h1,h2,h3,.heading{
   line-height: 1.05;
   color: #0C00C0;
   margin-bottom: .35rem;
+  display: inline-block;
+  transform-origin: center;
+  animation: winnerNameBreath 2.4s ease-in-out infinite;
 }
 
 .winner-congrats{


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia visual del anuncio del ganador sin tocar la lógica del sorteo ni el conteo mostrado en el overlay.  
- Evitar la animación de entrada única y proporcionar un efecto sutil y continuo (respiración) para el nombre del ganador.  
- Presentar la tarjeta principal del ganador en una ubicación más visible (debajo del mensaje de importación) y facilitar la navegación desde el overlay.

### Description
- Moví la tarjeta principal `¡Tenemos ganador!` fuera del bloque del premio y la inserté antes de la sección `Seleccionar ganador` en `index.html` (`winnerHeroSection`) para que quede centrada en la mitad de la página y debajo del mensaje `¡Listo! Se cargaron X participantes...`.  
- Reemplacé la animación de entrada de una sola ejecución por una animación CSS infinita tipo respiración definida como `@keyframes winnerNameBreath` y aplicada a `winner-hero-name` en `styles.css` (`scale(1) -> scale(1.05) -> scale(1)`, duración 2.4s, `ease-in-out`, `infinite`).  
- Cambié el texto del botón del overlay de `Nuevo sorteo` a `Ver ganador` en `index.html` y ajusté el manejador para que al pulsarlo se cierre el overlay y haga `scrollIntoView` suave hacia la tarjeta principal del ganador sin alterar la funcionalidad existente del overlay.  
- Ajusté el JavaScript para mostrar/ocultar la nueva `winnerHeroSection` cuando hay un `heroWinner`, y mantuve intacta la lógica de selección de ganadores, el contador y el número ganador mostrado en el overlay; sólo añadí una opción para hacer foco visual en la tarjeta al cerrar el overlay.

### Testing
- Ejecuté `git diff --check` y no arrojó problemas (succeeded).  
- Levanté un servidor local con `python3 -m http.server 4173` y confirmé que `index.html` carga correctamente (succeeded).  
- Validé visualmente con un script de Playwright que muestra la nueva ubicación y estado de la tarjeta y generé una captura `artifacts/winner-layout.png` (succeeded).  
- Confirmé que no se modificó la lógica de selección de ganadores ni el comportamiento del contador/numero en el overlay (manual verification via the running instance and preserved JS code paths).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab44542808832f940f322b187dae2d)