### PR TITLE
Agregar overlay final fullscreen para revelar ganador

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,14 +89,6 @@
                 </div>
             </div>
 
-            <div id="winnerHeroSection" class="winner-hero-section mb-8" style="display: none;">
-                <div id="winnerDisplay" class="winner-highlight-card card p-6 text-center">
-                    <h3 class="winner-highlight-title">¡Tenemos ganador!</h3>
-                    <div id="winnerHeroName" class="winner-hero-name"></div>
-                    <p id="winnerCongrats" class="winner-congrats">¡Muchas felicidades!</p>
-                </div>
-            </div>
-
             <div class="card p-6" id="raffleSection" style="display: none;">
                 <h2 class="text-xl font-semibold mb-4">Seleccionar ganador</h2>
                 
@@ -152,13 +144,21 @@
     </div>
 
     <div id="countdownOverlay" class="countdown-overlay hidden" aria-hidden="true">
-        <button id="closeOverlayBtn" class="overlay-close-btn hidden" type="button" aria-label="Cerrar overlay de ganador">×</button>
         <div id="countdownNumber" class="countdown-number">10</div>
         <div id="overlayNumberTicker" class="overlay-number-ticker hidden" aria-live="polite"></div>
         <div id="overlayWinnerContent" class="overlay-winner-content hidden">
             <p class="overlay-winner-label">El ganador es</p>
             <div id="overlayWinnerNumber" class="overlay-winner-number"></div>
             <button id="overlayNewDrawBtn" class="btn-primary overlay-new-draw-btn" type="button">Ver ganador</button>
+        </div>
+    </div>
+
+    <div id="winnerRevealOverlay" class="winner-reveal-overlay hidden" aria-hidden="true">
+        <div class="winner-reveal-content">
+            <p class="winner-reveal-title">¡Tenemos ganador!</p>
+            <div id="winnerRevealName" class="winner-reveal-name"></div>
+            <p class="winner-reveal-subtitle">¡Muchas felicidades!</p>
+            <button id="winnerRevealNewDrawBtn" class="btn-primary overlay-new-draw-btn" type="button">Nuevo sorteo</button>
         </div>
     </div>
 
@@ -183,7 +183,6 @@
         const winnerContainer = document.getElementById('winnerContainer');
         const winnerList = document.getElementById('winnerList');
         const displayPrize = document.getElementById('displayPrize');
-        const winnerHeroSection = document.getElementById('winnerHeroSection');
         const newDrawBtn = document.getElementById('newDrawBtn');
         const prizeNameInput = document.getElementById('prizeName');
         const winnerCountSelect = document.getElementById('winnerCount');
@@ -192,10 +191,10 @@
         const overlayNumberTicker = document.getElementById('overlayNumberTicker');
         const overlayWinnerContent = document.getElementById('overlayWinnerContent');
         const overlayWinnerNumber = document.getElementById('overlayWinnerNumber');
-        const winnerHeroName = document.getElementById('winnerHeroName');
-        const winnerCongrats = document.getElementById('winnerCongrats');
-        const closeOverlayBtn = document.getElementById('closeOverlayBtn');
         const overlayNewDrawBtn = document.getElementById('overlayNewDrawBtn');
+        const winnerRevealOverlay = document.getElementById('winnerRevealOverlay');
+        const winnerRevealName = document.getElementById('winnerRevealName');
+        const winnerRevealNewDrawBtn = document.getElementById('winnerRevealNewDrawBtn');
         const importSuccessMessage = document.getElementById('importSuccessMessage');
 
         let isCountdownRunning = false;
@@ -473,9 +472,10 @@
             drawBtn.disabled = true;
             winnerContainer.style.display = 'none';
             countdownNumber.classList.remove('hidden');
-            closeOverlayBtn.classList.add('hidden');
             overlayWinnerContent.classList.add('hidden');
             overlayWinnerNumber.textContent = '';
+            winnerRevealOverlay.classList.add('hidden');
+            winnerRevealOverlay.setAttribute('aria-hidden', 'true');
             startOverlayTicker();
             countdownOverlay.classList.remove('hidden');
             countdownOverlay.setAttribute('aria-hidden', 'false');
@@ -531,9 +531,7 @@
 
             // Mostrar ganadores en la tarjeta inferior
             const heroWinner = winners[0];
-            winnerHeroName.textContent = heroWinner ? heroWinner.name : '';
-            winnerHeroSection.style.display = heroWinner ? 'block' : 'none';
-            winnerCongrats.style.display = heroWinner ? 'block' : 'none';
+            winnerRevealName.textContent = heroWinner ? heroWinner.name : '';
 
             winners.forEach((winner, index) => {
                 const winnerElement = document.createElement('div');
@@ -552,37 +550,45 @@
             countdownNumber.classList.add('hidden');
             overlayWinnerNumber.textContent = winnerNumber ? `N.° ${winnerNumber}` : '';
             stopOverlayTicker(winnerNumber);
-            closeOverlayBtn.classList.remove('hidden');
             overlayWinnerContent.classList.remove('hidden');
 
             drawBtn.disabled = false;
             isCountdownRunning = false;
         }
 
-        function closeOverlay(focusWinnerSection = false) {
+        function closeOverlay() {
             countdownOverlay.classList.add('hidden');
             countdownOverlay.setAttribute('aria-hidden', 'true');
             countdownNumber.classList.remove('hidden');
-            closeOverlayBtn.classList.add('hidden');
             overlayWinnerContent.classList.add('hidden');
             overlayNumberTicker.classList.add('hidden');
             overlayWinnerNumber.textContent = '';
             stopOverlayTicker();
             drawBtn.disabled = false;
             isCountdownRunning = false;
-
-            if (focusWinnerSection && winnerHeroSection.style.display !== 'none') {
-                winnerHeroSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            }
         }
 
-        closeOverlayBtn.addEventListener('click', () => closeOverlay(false));
-        overlayNewDrawBtn.addEventListener('click', () => closeOverlay(true));
+        function closeWinnerRevealOverlay() {
+            winnerRevealOverlay.classList.add('hidden');
+            winnerRevealOverlay.setAttribute('aria-hidden', 'true');
+        }
+
+        overlayNewDrawBtn.addEventListener('click', () => {
+            closeOverlay();
+            winnerRevealOverlay.classList.remove('hidden');
+            winnerRevealOverlay.setAttribute('aria-hidden', 'false');
+        });
+
+        winnerRevealNewDrawBtn.addEventListener('click', () => {
+            closeWinnerRevealOverlay();
+            winnerContainer.style.display = 'none';
+            prizeNameInput.focus();
+        });
 
         // Evento para nuevo sorteo
         newDrawBtn.addEventListener('click', () => {
             winnerContainer.style.display = 'none';
-            winnerHeroSection.style.display = 'none';
+            closeWinnerRevealOverlay();
             prizeNameInput.focus();
         });
     </script>

--- a/styles.css
+++ b/styles.css
@@ -166,22 +166,6 @@ h1,h2,h3,.heading{
 }
 
 
-.winner-highlight-card{
-  max-width: 700px;
-  margin: 0 auto;
-}
-
-.winner-hero-section{
-  width: 100%;
-}
-
-.winner-highlight-title{
-  font-family: 'Atkinson Hyperlegible', sans-serif;
-  font-size: clamp(1.2rem, 2.8vw, 1.6rem);
-  color: #0C00C0;
-  margin: 0 0 .6rem;
-}
-
 @keyframes winnerNameBreath{
   0%{
     transform: scale(1);
@@ -198,23 +182,6 @@ h1,h2,h3,.heading{
   font-family: 'FF Nort Headline', 'Atkinson Hyperlegible', sans-serif;
 }
 
-.winner-hero-name{
-  font-family: 'FF Nort Headline', 'Atkinson Hyperlegible', sans-serif;
-  font-size: clamp(2.4rem, 6vw, 4.8rem);
-  line-height: 1.05;
-  color: #0C00C0;
-  margin-bottom: .35rem;
-  display: inline-block;
-  transform-origin: center;
-  animation: winnerNameBreath 2.4s ease-in-out infinite;
-}
-
-.winner-congrats{
-  font-family: 'Atkinson Hyperlegible', sans-serif;
-  font-size: 1rem;
-  color: #4b5563;
-  margin: 0 0 1rem;
-}
 
 .overlay-winner-label{
   font-family: 'Atkinson Hyperlegible', sans-serif;
@@ -248,34 +215,6 @@ h1,h2,h3,.heading{
   display: none;
 }
 
-.overlay-close-btn{
-  position: absolute;
-  top: 1.25rem;
-  right: 1.25rem;
-  width: 2.75rem;
-  height: 2.75rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  background: rgba(0, 0, 0, 0.35);
-  color: #fff;
-  font-family: 'Atkinson Hyperlegible', sans-serif;
-  font-size: 2rem;
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.overlay-close-btn:hover{
-  background: rgba(255, 255, 255, 0.2);
-  transform: scale(1.05);
-}
-
-.overlay-close-btn.hidden{
-  display: none;
-}
 
 .overlay-winner-content{
   display: flex;
@@ -293,4 +232,60 @@ h1,h2,h3,.heading{
   font-family: 'Atkinson Hyperlegible', sans-serif;
   min-width: 11rem;
   text-align: center;
+}
+
+
+.winner-reveal-overlay{
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: radial-gradient(circle at top, rgba(45,66,255,0.35), rgba(0,0,0,0.96) 55%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 3.5rem);
+}
+
+.winner-reveal-overlay.hidden{
+  display: none;
+}
+
+.winner-reveal-content{
+  width: min(1200px, 100%);
+  min-height: min(76vh, 900px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: clamp(1rem, 2.4vw, 2rem);
+}
+
+.winner-reveal-title,
+.winner-reveal-subtitle{
+  font-family: 'Atkinson Hyperlegible', sans-serif;
+  color: #fff;
+  margin: 0;
+}
+
+.winner-reveal-title{
+  font-size: clamp(1.5rem, 3vw, 2.3rem);
+}
+
+.winner-reveal-name{
+  font-family: 'FF Nort Headline', 'Atkinson Hyperlegible', sans-serif;
+  font-size: clamp(3.2rem, 11vw, 11rem);
+  line-height: 0.95;
+  letter-spacing: 0.02em;
+  color: #fff;
+  margin: 0.3rem 0;
+  display: inline-block;
+  transform-origin: center;
+  animation: winnerNameBreath 2.6s ease-in-out infinite;
+  text-wrap: balance;
+}
+
+.winner-reveal-subtitle{
+  font-size: clamp(1.05rem, 2.6vw, 1.8rem);
+  color: rgba(255,255,255,0.92);
 }


### PR DESCRIPTION
### Motivation
- Mejorar la presentación final del ganador sin tocar la lógica del sorteo, haciendo que el nombre sea el protagonista absoluto en una segunda pantalla de revelación.

### Description
- Se eliminó la tarjeta protagonista central de la página principal para que el nombre no compita visualmente con la interfaz principal y el protagonismo se reserve a overlays.\
- Se mantuvo el primer overlay oscuro que muestra solo `"El ganador es"` y `"N.° X"` con el botón azul `Ver ganador`.\
- Se agregó un segundo overlay fullscreen (`winnerRevealOverlay`) que muestra centrado `"¡Tenemos ganador!"`, el nombre en tamaño muy grande con animación de respiración continua (`scale(1) → scale(1.05) → scale(1)`), `"¡Muchas felicidades!"` y el botón azul `Nuevo sorteo`.\
- Se ajustó el JavaScript para el flujo pedido: conteo + overlay de número → al hacer click en `Ver ganador` se abre el overlay final con el nombre → al hacer click en `Nuevo sorteo` se cierra y deja la vista lista para un nuevo sorteo, sin cambiar la selección aleatoria ni los cálculos existentes.
- Archivos modificados: `index.html` y `styles.css`.

### Testing
- Se lanzó un servidor estático con `python -m http.server` y la página fue servida correctamente (automated). — Éxito.\
- Se ejecutó un script de Playwright que simuló el estado de ambos overlays y generó la captura `artifacts/winner-overlay-final.png` para validar la apariencia fullscreen y la animación del nombre. — Éxito.\
- Se verificó con búsquedas automáticas (`rg`) que los selectores/IDs relevantes están presentes y que la sección de tarjeta del ganador fue eliminada del DOM principal. — Éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab47977054832f99a6c861773af5a6)