### PR TITLE
Mostrar premio en overlay de revelación del ganador

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,10 @@
         <div class="winner-reveal-content">
             <p class="winner-reveal-title">¡Tenemos ganador!</p>
             <div id="winnerRevealName" class="winner-reveal-name"></div>
+            <div class="winner-reveal-prize">
+                <p class="winner-reveal-prize-label">Premio</p>
+                <p id="winnerRevealPrize" class="winner-reveal-prize-value"></p>
+            </div>
             <p class="winner-reveal-subtitle">¡Muchas felicidades!</p>
             <button id="winnerRevealNewDrawBtn" class="btn-primary overlay-new-draw-btn" type="button">Nuevo sorteo</button>
         </div>
@@ -194,6 +198,7 @@
         const overlayNewDrawBtn = document.getElementById('overlayNewDrawBtn');
         const winnerRevealOverlay = document.getElementById('winnerRevealOverlay');
         const winnerRevealName = document.getElementById('winnerRevealName');
+        const winnerRevealPrize = document.getElementById('winnerRevealPrize');
         const winnerRevealNewDrawBtn = document.getElementById('winnerRevealNewDrawBtn');
         const importSuccessMessage = document.getElementById('importSuccessMessage');
 
@@ -532,6 +537,7 @@
             // Mostrar ganadores en la tarjeta inferior
             const heroWinner = winners[0];
             winnerRevealName.textContent = heroWinner ? heroWinner.name : '';
+            winnerRevealPrize.textContent = prize;
 
             winners.forEach((winner, index) => {
                 const winnerElement = document.createElement('div');

--- a/styles.css
+++ b/styles.css
@@ -268,6 +268,33 @@ h1,h2,h3,.heading{
   margin: 0;
 }
 
+.winner-reveal-prize{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: -0.1rem;
+}
+
+.winner-reveal-prize-label,
+.winner-reveal-prize-value{
+  font-family: 'Atkinson Hyperlegible', sans-serif;
+  color: #fff;
+  margin: 0;
+}
+
+.winner-reveal-prize-label{
+  font-size: clamp(1rem, 2vw, 1.5rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.winner-reveal-prize-value{
+  font-size: clamp(1.2rem, 3vw, 2.1rem);
+  color: rgba(255,255,255,0.95);
+  text-wrap: balance;
+}
+
 .winner-reveal-title{
   font-size: clamp(1.5rem, 3vw, 2.3rem);
 }


### PR DESCRIPTION
### Motivation
- Agregar la visualización del texto del campo "Premio" en el segundo overlay de revelación para mostrar debajo del nombre del ganador el premio informado por el usuario sin alterar la lógica del sorteo.

### Description
- Se añadió en el HTML del `winnerRevealOverlay` un bloque `.winner-reveal-prize` con etiqueta `Premio` y un elemento con id `winnerRevealPrize` para el valor dinámico. 
- Se incorporó CSS para `.winner-reveal-prize`, `.winner-reveal-prize-label` y `.winner-reveal-prize-value` manteniendo el contenido centrado, la jerarquía visual y la animación existente del nombre. 
- Se realizó un ajuste mínimo en JavaScript: se captura `winnerRevealPrize` y se asigna `prize` al revelar al ganador (`winnerRevealPrize.textContent = prize`).

### Testing
- Se levantó un servidor local y se comprobó la visualización del overlay activando el DOM con datos de ejemplo; la página se sirvió correctamente. (éxito)
- Se generó una captura de pantalla automática del overlay usando Playwright para verificar la posición y estilo del premio; la imagen resultante confirma el diseño esperado. (éxito)
- Se ejecutó una verificación de diff/format para asegurarse de no introducir errores de formato en los archivos modificados; no se detectaron problemas. (éxito)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab613c1c48832f9ea06061381e0fc5)