### PR TITLE
Reset completo al pulsar "Nuevo sorteo"

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,7 @@
         const participantsSection = document.getElementById('participantsSection');
         const raffleSection = document.getElementById('raffleSection');
         const participantsTable = document.getElementById('participantsTable');
+        const participantsTableWrapper = document.getElementById('participantsTableWrapper');
         const participantCount = document.getElementById('participantCount');
         const drawBtn = document.getElementById('drawBtn');
         const winnerContainer = document.getElementById('winnerContainer');
@@ -201,6 +202,7 @@
         const winnerRevealPrize = document.getElementById('winnerRevealPrize');
         const winnerRevealNewDrawBtn = document.getElementById('winnerRevealNewDrawBtn');
         const importSuccessMessage = document.getElementById('importSuccessMessage');
+        const defaultDropAreaText = 'Sube tu lista de participantes en formato Excel';
 
         let isCountdownRunning = false;
         let importMessageTimeout = null;
@@ -562,6 +564,71 @@
             isCountdownRunning = false;
         }
 
+
+        function resetRaffleApp() {
+            participants = [];
+            winners = [];
+            workbook = null;
+            selectedFileName = '';
+            isCountdownRunning = false;
+
+            if (importMessageTimeout) {
+                clearTimeout(importMessageTimeout);
+                importMessageTimeout = null;
+            }
+
+            stopOverlayTicker();
+
+            // Limpiar input y área de carga
+            fileInput.value = '';
+            const dropText = dropArea.querySelector('p:first-of-type');
+            dropText.textContent = defaultDropAreaText;
+            dropArea.classList.remove('bg-blue-50', 'active');
+
+            // Limpiar errores y mensajes
+            const fileError = document.getElementById('fileError');
+            fileError.textContent = '';
+            fileError.classList.add('hidden');
+            importSuccessMessage.innerHTML = '';
+            importSuccessMessage.classList.add('hidden');
+
+            // Restablecer importación
+            importBtn.disabled = true;
+            importBtn.innerHTML = 'Importar participantes';
+            nameColumnSelect.innerHTML = '<option value="">Selecciona columna...</option>';
+            emailColumnSelect.innerHTML = '<option value="">Selecciona columna...</option>';
+
+            // Limpiar participantes y resultados
+            participantsTable.innerHTML = '';
+            participantCount.textContent = '0';
+            participantsSection.style.display = 'none';
+            participantsTableWrapper.classList.add('participants-table-hidden');
+            raffleSection.style.display = 'none';
+            winnerContainer.style.display = 'none';
+            winnerList.innerHTML = '';
+            displayPrize.textContent = '';
+
+            // Limpiar campos del formulario
+            prizeNameInput.value = '';
+            winnerCountSelect.value = '1';
+
+            // Limpiar overlays
+            countdownOverlay.classList.add('hidden');
+            countdownOverlay.setAttribute('aria-hidden', 'true');
+            countdownNumber.classList.remove('hidden');
+            countdownNumber.textContent = '10';
+            overlayNumberTicker.classList.add('hidden');
+            overlayNumberTicker.textContent = '';
+            overlayWinnerContent.classList.add('hidden');
+            overlayWinnerNumber.textContent = '';
+            closeWinnerRevealOverlay();
+            winnerRevealName.textContent = '';
+            winnerRevealPrize.textContent = '';
+
+            drawBtn.disabled = false;
+            fileInput.focus();
+        }
+
         function closeOverlay() {
             countdownOverlay.classList.add('hidden');
             countdownOverlay.setAttribute('aria-hidden', 'true');
@@ -586,16 +653,14 @@
         });
 
         winnerRevealNewDrawBtn.addEventListener('click', () => {
-            closeWinnerRevealOverlay();
-            winnerContainer.style.display = 'none';
-            prizeNameInput.focus();
+            closeOverlay();
+            resetRaffleApp();
         });
 
         // Evento para nuevo sorteo
         newDrawBtn.addEventListener('click', () => {
-            winnerContainer.style.display = 'none';
-            closeWinnerRevealOverlay();
-            prizeNameInput.focus();
+            closeOverlay();
+            resetRaffleApp();
         });
     </script>
 </body>


### PR DESCRIPTION
### Motivation
- Al iniciar un "Nuevo sorteo" la app a veces conservaba en memoria el Excel y datos previos; se necesita un reinicio total de estado y UI sin cambiar la lógica del sorteo.

### Description
- Añadida la función `resetRaffleApp()` que limpia en memoria `participants`, `winners`, `workbook` y `selectedFileName`, detiene tickers y timeouts, y restablece el foco al `fileInput`.
- La función también limpia explícitamente el input de archivo con `fileInput.value = ''`, restaura el texto del área de carga usando `defaultDropAreaText`, y resetea mensajes (`importSuccessMessage`, `fileError`), selects de columnas (`nameColumnSelect`, `emailColumnSelect`), tabla y contador de participantes, campos de premio y selector de número de ganadores, overlays y resultados visibles.
- Se añadió la referencia `participantsTableWrapper` y la constante `defaultDropAreaText` para soportar el reset visual del área de carga.
- Conectada la función `resetRaffleApp()` a los botones `newDrawBtn` y `winnerRevealNewDrawBtn` para que ambos flujos inicien la app desde cero sin recargar la página.

### Testing
- Ejecutado un chequeo de sintaxis/ejecución del script inline con Node usando `new Function(js)` y la verificación devolvió `JS OK` (pasó).
- No se agregaron tests unitarios automáticos; los cambios fueron validados localmente mediante el chequeo de ejecución y se registró un commit con los cambios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab66cc418c832f918745acc1c7a850)